### PR TITLE
show all payment methods list (active/not active) fix issue #3

### DIFF
--- a/Plugin/Block/Aminhtml/Group/Edit/FormPlugin.php
+++ b/Plugin/Block/Aminhtml/Group/Edit/FormPlugin.php
@@ -84,7 +84,13 @@ class FormPlugin
      */
     private function getPaymentMethodsList()
     {
-        $paymentOptions = $this->paymentHelper->getPaymentMethodList();
+        $paymentOptions = [];
+        $allpaymentmethods=$this->paymentHelper->getPaymentMethods();
+
+        foreach ($allpaymentmethods as $code => $data) {
+            if(!isset($data['title'])) continue; //skip if payment method not have name
+            $paymentOptions[$code] = $data['title'];
+        }
 
         return array_filter(array_map(function ($paymentMethodCode, $paymentMethodDescription) {
             if($paymentMethodDescription == '') return;


### PR DESCRIPTION
fix issue #3 
getPaymentMethodList() function show only active payment methods, in some case it not show some payment methods even if they are active like stripecreditcards
so i changed this function with getPaymentMethods() function and get code and title list from it 
![image](https://user-images.githubusercontent.com/22837086/61471061-01a1dc80-a97a-11e9-850e-15c5ac29e210.png)
