### PR TITLE
Use customer group of quote instead of current user for filter

### DIFF
--- a/Observer/PaymentMethodAvailable.php
+++ b/Observer/PaymentMethodAvailable.php
@@ -31,7 +31,7 @@ class PaymentMethodAvailable implements ObserverInterface
      */
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
-        $customerGroupId = $this->customerSession->getCustomer()->getGroupId();
+        $customerGroupId = $observer->getEvent()->getQuote()->getCustomerGroupId();
         $customerGroup = $this->groupRepository->getById($customerGroupId);
         $customerGroupDisabledPaymentMethods = $customerGroup->getExtensionAttributes()
             ->getDisallowedPaymentOptions()

--- a/Observer/PaymentMethodAvailable.php
+++ b/Observer/PaymentMethodAvailable.php
@@ -7,17 +7,12 @@ use Magento\Framework\Event\ObserverInterface;
 class PaymentMethodAvailable implements ObserverInterface
 {
     /**
-     * @var \Magento\Customer\Model\Session
-     */
-    private $customerSession;
-    /**
      * @var \Magento\Customer\Api\GroupRepositoryInterface
      */
     private $groupRepository;
 
-    public function __construct(\Magento\Customer\Model\Session $customerSession, \Magento\Customer\Api\GroupRepositoryInterface $groupRepository)
+    public function __construct(\Magento\Customer\Api\GroupRepositoryInterface $groupRepository)
     {
-        $this->customerSession = $customerSession;
         $this->groupRepository = $groupRepository;
     }
 


### PR DESCRIPTION
Fixes #7.

The quote object on the event is always populated even during frontend transactions, so there is no reason we can't use this (which is also populated correctly on admin interface transactions) instead of getting the current user.